### PR TITLE
Adding exception tracking to aurelia google analytics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ export function configure(aurelia) {
 				},
 				clickTracking: {
 					enabled: true // Set to `false` to disable in non-production environments.
+				},
+				exceptionTracking: {
+					enabled: true // Set to `false` to disable in non-production environments.
 				}
 			});	
 		});

--- a/dist/commonjs/analytics.js
+++ b/dist/commonjs/analytics.js
@@ -7,6 +7,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Analytics = undefined;
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 var _dec, _class;
 
 var _aureliaDependencyInjection = require('aurelia-dependency-injection');
@@ -42,6 +44,11 @@ var defaultOptions = {
 		filter: function filter(element) {
 			return element instanceof HTMLElement && (element.nodeName.toLowerCase() === 'a' || element.nodeName.toLowerCase() === 'button');
 		}
+	},
+	exceptionTracking: {
+		enabled: true,
+		applicationName: undefined,
+		applicationVersion: undefined
 	}
 };
 
@@ -105,6 +112,7 @@ var Analytics = exports.Analytics = (_dec = (0, _aureliaDependencyInjection.inje
 
 		this._attachClickTracker();
 		this._attachPageTracker();
+		this._attachExceptionTracker();
 	};
 
 	Analytics.prototype.init = function init(id) {
@@ -139,6 +147,52 @@ var Analytics = exports.Analytics = (_dec = (0, _aureliaDependencyInjection.inje
 		this._eventAggregator.subscribe('router:navigation:success', function (payload) {
 			_this._trackPage(payload.instruction.fragment, _this._options.pageTracking.getTitle(payload));
 		});
+	};
+
+	Analytics.prototype._attachExceptionTracker = function _attachExceptionTracker() {
+		if (!this._options.exceptionTracking.enabled) {
+			return;
+		}
+
+		var options = this._options;
+		var existingWindowErrorCallback = window.onerror;
+
+		window.onerror = function (errorMessage, url, lineNumber, columnNumber, errorObject) {
+			if (typeof ga === 'function') {
+				var exceptionDescription = void 0;
+				if (errorObject != undefined && _typeof(errorObject.message) != undefined) {
+					exceptionDescription = errorObject.message;
+				} else {
+					exceptionDescription = errorMessage;
+				}
+
+				exceptionDescription += " @ " + url;
+
+				if (lineNumber != undefined && columnNumber != undefined) {
+					exceptionDescription += ":" + lineNumber + ":" + columnNumber;
+				}
+
+				var exOptions = {
+					exDescription: exceptionDescription,
+					exFatal: false
+				};
+
+				if (options.exceptionTracking.applicationName != undefined) {
+					exOptions.appName = options.exceptionTracking.applicationName;
+				}
+				if (options.exceptionTracking.applicationVersion != undefined) {
+					exOptions.appVersion = options.exceptionTracking.applicationVersion;
+				}
+
+				ga('send', 'exception', exOptions);
+			}
+
+			if (typeof existingWindowErrorCallback === 'function') {
+				return existingWindowErrorCallback(errorMessage, url, lineNumber, columnNumber, errorObject);
+			}
+
+			return false;
+		};
 	};
 
 	Analytics.prototype._log = function _log(level, message) {


### PR DESCRIPTION
Exceptions that occur within window.onerror are sent for tracking in google analytics. It doesn't look like the data is very robust, but at least there can be some level of tracking of the amount of client side errors that occurring.

Based on analytics documentation:
https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions

and example:
https://philsawicki.github.io/GoogleAnalytics-WebTester/examples-exception-tracking.html

Tested within my own project.