### PR TITLE
Possibility to use external tracking to dispatch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install aurelia-google-analytics --save
 export function configure(aurelia) {
 	aurelia.use.plugin('aurelia-google-analytics', config => {
 		config.init('<Your Tracker ID>');
-		config.attach({
+		const options = {
 			logging: {
 				// Set to `true` to have some log messages appear in the browser console.
 				enabled: true
@@ -61,7 +61,8 @@ export function configure(aurelia) {
 				// Set to `false` to disable in non-production environments.
 				enabled: true
 			}
-		});
+		};
+		config.attach(options);
 	});
 
 	aurelia.start().then(a => a.setRoot());
@@ -79,6 +80,90 @@ export function configure(aurelia) {
 ```
 
 In order to use the click tracking feature, each HTML element you want to track must contain a `data-analytics-category` and `data-analytics-action` attribute. `data-analytics-label` and `data-analytics-value` are supported and optional.
+
+
+### Alternative trackings
+
+For custom trackings, for example, if you want to use the simplicity of the `aurelia-google-analytics` but tracking using Google Tag Manager (GTM) ou similars, you can use custom functions passing these function in `options`.
+
+In this case, see options below:
+
+`options.useNativeGaScript` _(default: true)_
+
+Passing `false` in this option to disable native script of GA. The `aurelia-google-analytics` don't load the `<script>` tag to Google Analytics (GA). It's good when you load GA from GTM for example.
+
+With this option disabled, the `aurelia-google-analytics` automatically set internal lib as `loaded`, so you don't need to execute `config.init`.
+
+
+`options.pageTracking.customFnTrack` _(default: false)_
+
+You can pass a function in this option to customize the tracking of pages. For example, if you use GTM, perhaps do you want to track events sending data to you `dataLayer` variable.
+
+For example:
+
+```javascript
+
+const options = {
+	// ...
+	pageTracking: {
+		customFnTrack: (props) => {
+			console.log(props);
+			/*
+			prints in console:
+			{ 
+				page: '',
+				title: '',
+				anonymizeIp: true/false
+			}
+			*/
+			window.dataLayer = window.dataLayer || [];
+			window.dataLayer.push(Object.assign(
+				{
+				event: 'virtual-page-tracking',
+				},
+				props
+			));
+		}
+	}
+	// ...
+}
+```
+
+`options.clickTracking.customFnTrack` _(default: false)_
+
+Same of `options.pageTracking.customFnTrack`, but for links.
+
+For example:
+
+
+```javascript
+
+const options = {
+	// ...
+	clickTracking: {
+		customFnTrack: (props) => {
+			console.log(props);
+			/*
+			prints in console:
+			{ 
+				category: // value of atribute 'data-analytics-category',
+				action: // value of atribute 'data-analytics-action',
+				label: // value of atribute 'data-analytics-label',
+				value: // value of atribute 'data-analytics-value'
+			}
+			*/
+			window.dataLayer = window.dataLayer || [];
+			window.dataLayer.push(Object.assign(
+				{
+				event: 'ga-event',
+				},
+				props
+			));
+		}
+	}
+	// ...
+}
+```
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ npm install aurelia-google-analytics --save
 ```javascript
 export function configure(aurelia) {
 	aurelia.use.plugin('aurelia-google-analytics', config => {
-		config.init('<Your Tracker ID>');
 		const options = {
 			logging: {
 				// Set to `true` to have some log messages appear in the browser console.
@@ -63,6 +62,7 @@ export function configure(aurelia) {
 			}
 		};
 		config.attach(options);
+		config.init('<Your Tracker ID>');
 	});
 
 	aurelia.start().then(a => a.setRoot());

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -18,7 +18,6 @@ import deepmerge from 'deepmerge';
 
 /*
 .plugin('aurelia-google-analytics', config => {
-			config.init('<Tracker ID here>');
 			config.attach({
 				customTracking: {
 					useNativeGaScript: true
@@ -49,6 +48,7 @@ import deepmerge from 'deepmerge';
 					}
 				}
 			});
+			config.init('<Tracker ID here>');
 		})
 */
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -20,6 +20,9 @@ import deepmerge from 'deepmerge';
 .plugin('aurelia-google-analytics', config => {
 			config.init('<Tracker ID here>');
 			config.attach({
+				customTracking: {
+					useNativeGaScript: true
+				},
 				logging: {
 					enabled: true
 				},
@@ -75,6 +78,7 @@ const criteria = {
 };
 
 const defaultOptions = {
+	useNativeGaScript: true,
 	logging: {
 		enabled: true
 	},
@@ -93,18 +97,21 @@ const defaultOptions = {
 		},
 		getUrl: (payload) => {
 			return payload.instruction.fragment;
-		}
+		},
+		customFnTrack: false,
 	},
 	clickTracking: {
 		enabled: false,
 		filter: (element) => {
 			return criteria.isAnchor(element) || criteria.isButton(element);
-		}
+		},
+		customFnTrack: false,
 	},
 	exceptionTracking: {
 		enabled: true,
 		applicationName: undefined,
-		applicationVersion: undefined
+		applicationVersion: undefined,
+		customFnTrack: false,
 	}
 };
 
@@ -131,6 +138,10 @@ export class Analytics {
 
 		this._trackClick = this._trackClick.bind(this);
 		this._trackPage = this._trackPage.bind(this);
+
+		if (!this._options.useNativeGaScript) {
+			this._initialized = true;
+		}
 	}
 
 	attach(options = defaultOptions) {
@@ -147,6 +158,10 @@ export class Analytics {
 	}
 
 	init(id) {
+		if (!this._options.useNativeGaScript) {
+			return;
+		}
+
 		const script = document.createElement('script');
 		script.text = "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){" +
 			"(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o)," +
@@ -154,13 +169,22 @@ export class Analytics {
 			"})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');";
 		document.querySelector('body').appendChild(script);
 
+		this._initFnGa();
+		ga.l = +new Date;
+		this._sendFnGa('create', id, 'auto');
+
+		this._initialized = true;
+	}
+
+	_initFnGa() {
 		window.ga = window.ga || function () {
 			(ga.q = ga.q || []).push(arguments)
 		};
-		ga.l = +new Date;
-		ga('create', id, 'auto');
+	}
 
-		this._initialized = true;
+	_sendFnGa() {
+		this._initFnGa();
+		window.ga.apply(window.ga, arguments);
 	}
 
 	_attachClickTracker() {
@@ -229,7 +253,10 @@ export class Analytics {
 					exOptions.appVersion = options.exceptionTracking.applicationVersion;
 				}
 
-				ga('send', 'exception', exOptions);
+				if (options.exceptionTracking.customFnTrack) {
+					return options.exceptionTracking.customFnTrack(exOptions);
+				}
+				this._sendFnGa('send', 'exception', exOptions);
 			}
 
 			if (typeof existingWindowErrorCallback === 'function') {
@@ -267,7 +294,11 @@ export class Analytics {
 		};
 
 		this._log('debug', `click: category '${tracking.category}', action '${tracking.action}', label '${tracking.label}', value '${tracking.value}'`);
-		ga('send', 'event', tracking.category, tracking.action, tracking.label, tracking.value);
+		if (this._options.clickTracking.customFnTrack) {
+			return this._options.clickTracking.customFnTrack(tracking);
+		}
+
+		this._sendFnGa('send', 'event', tracking.category, tracking.action, tracking.label, tracking.value);
 	}
 
 	_trackPage(path, title) {
@@ -277,11 +308,17 @@ export class Analytics {
 			return;
 		}
 
-		ga('set', {
+		const props = {
 			page: path,
 			title: title,
 			anonymizeIp: this._options.anonymizeIp.enabled
-		});
-		ga('send', 'pageview');
+		};
+
+		if (this._options.pageTracking.customFnTrack) {
+			return this._options.pageTracking.customFnTrack(props);
+		}
+
+		this._sendFnGa('set', props);
+		this._sendFnGa('send', 'pageview');
 	}
 }

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -138,14 +138,15 @@ export class Analytics {
 
 		this._trackClick = this._trackClick.bind(this);
 		this._trackPage = this._trackPage.bind(this);
-
-		if (!this._options.useNativeGaScript) {
-			this._initialized = true;
-		}
 	}
 
 	attach(options = defaultOptions) {
 		this._options = deepmerge(defaultOptions, options);
+
+		if (!this._options.useNativeGaScript) {
+			this._initialized = true;
+		}
+		
 		if (!this._initialized) {
 			const errorMessage = "Analytics must be initialized before use.";
 			this._log('error', errorMessage);


### PR DESCRIPTION
I added the possibility to use this code with external tracking.
I assumed a project on production, and that project uses this package in many code locations.
And one task was to migrate trackings to GTM.
To reutilize all implementation of this plugin on code, I only created an adjustments to not remove and continue using all code, now using GTM trackings on the dataLayer.

I am sharing changes here.